### PR TITLE
ci: Update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,61 +17,84 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
       - name: Install build requirements
         run: |
           pip install -U pip
           pip install build
+
       - name: Build
         run: python -m build
+
       - name: Install
         run: pip install dist/*.whl
+
       - name: Test import
         run: |
           mkdir tmp
           cd tmp
           python -c "import ansys.api.mechanical; print('Successfully imported ansys.api.mechanical')"
           python -c "from ansys.api.mechanical import __version__; print(__version__)"
+
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ansys-api-mechanical-packages
+          name: ansys-api-mechanical-artifacts
           path: dist/
           retention-days: 7
 
-  Release:
+  release-github:
+    name: Release package to GitHub
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build]
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-      - uses: actions/download-artifact@v4
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Upload to Public PyPi
-        run: |
-          pip install twine
-          twine upload --skip-existing ./**/*.whl
-          twine upload --skip-existing ./**/*.tar.gz
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.ANSYS_API_MECHANICAL_PYPI_TOKEN }} 
+          name: ansys-api-mechanical-artifacts
+          path: ansys-api-mechanical-artifacts
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           generate_release_notes: true
           files: |
             ./**/*.whl
             ./**/*.tar.gz
-            ./**/*.pdf
+
+  release-pypi:
+    name: Release project to PyPI
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ansys-api-mechanical-artifacts
+          path: ansys-api-mechanical-artifacts
+
+      - name: "Upload artifacts to PyPI using trusted publisher"
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ansys-api-mechanical-artifacts
+          skip-existing: false


### PR DESCRIPTION
- Pin versions of actions using hashes
- Update the release-pypi job to use the trusted publisher approach