### PR TITLE
fix: Change name of packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload packages
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ansys-api-mechanical-artifacts
+          name: ansys-api-mechanical-packages
           path: dist/
           retention-days: 7
 
@@ -63,8 +63,8 @@ jobs:
       - name: "Download the library artifacts from build-library step"
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: ansys-api-mechanical-artifacts
-          path: ansys-api-mechanical-artifacts
+          name: ansys-api-mechanical-packages
+          path: ansys-api-mechanical-packages
 
       - name: Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
@@ -85,16 +85,16 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: "Download the library artifacts from build-library step"
+      - name: "Download the library packages from build-library step"
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: ansys-api-mechanical-artifacts
-          path: ansys-api-mechanical-artifacts
+          name: ansys-api-mechanical-packages
+          path: ansys-api-mechanical-packages
 
-      - name: "Upload artifacts to PyPI using trusted publisher"
+      - name: "Upload packages to PyPI using trusted publisher"
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           repository-url: "https://upload.pypi.org/legacy/"
           print-hash: true
-          packages-dir: ansys-api-mechanical-artifacts
+          packages-dir: ansys-api-mechanical-packages
           skip-existing: false


### PR DESCRIPTION
Switch `ansys-api-mechanical-artifacts` back to `ansys-api-mechanical-packages`